### PR TITLE
Fix type of return value by data.find

### DIFF
--- a/proxy.cpp
+++ b/proxy.cpp
@@ -11,13 +11,13 @@ void injection(struct usb_raw_transfer_io &io, Json::Value patterns, std::string
 		std::string pattern_hex = patterns[j].asString();
 		std::string pattern = hexToAscii(pattern_hex);
 
-		__u32 pos = data.find(pattern);
+		std::string::size_type pos = data.find(pattern);
 		while (pos != std::string::npos) {
 			if (data.length() - pattern.length() + replacement.length() > 1023)
 				break;
 
 			data = data.replace(pos, pattern.length(), replacement);
-			printf("Modified from %s to %s at Index %d\n", pattern_hex.c_str(), replacement_hex.c_str(), pos);
+			printf("Modified from %s to %s at Index %ld\n", pattern_hex.c_str(), replacement_hex.c_str(), pos);
 			data_modified = true;
 
 			pos = data.find(pattern);


### PR DESCRIPTION
Hi.

I use usb-proxy to analyze USB devices and it is very useful.
However, it required minor fix to use injection feature in my environment.

## Problem
In aarch64, a `std::out_of_range` exception is thrown if a injection rule doesn't match.

```
pi@raspberrypi:~/work/usb-proxy $ lsb_release -d
Description:    Debian GNU/Linux 11 (bullseye)
pi@raspberrypi:~/work/usb-proxy $ uname -a
Linux raspberrypi 5.15.56-v8+ #1575 SMP PREEMPT Fri Jul 22 20:31:26 BST 2022 aarch64 GNU/Linux
pi@raspberrypi:~/work/usb-proxy $ sudo ./usb-proxy --device=fe980000.usb --driver=fe980000.usb --vendor_id=0590 --product_id=001a --enable_injection
Device is: fe980000.usb
Driver is: fe980000.usb
vendor_id is: 1424
product_id is: 26
Injection enabled
Parsed injection file: injection.json
Device opened successfully
Setup USB config successfully
Start hotplug_monitor thread, thread id(32888)
Start for EP0, thread id(32886)
event: connect, length: 0
event: control, length: 8
  bRequestType: 0x80  (IN), bRequest: 0x06, wValue: 0x0100, wIndex: 0x0000, wLength: 8
  type = USB_TYPE_STANDARD
  req = USB_REQ_GET_DESCRIPTOR
  desc = USB_DT_DEVICE
terminate called after throwing an instance of 'std::out_of_range'
  what():  basic_string::replace: __pos (which is 4294967295) > this->size() (which is 8)
Aborted
```
`std::basic_string::find` returns `std::string::npos` if the pattern doesn't match.
`std::string::npos` is `18446744073709551615UL` in aarch64, but when it is assigned to `__u32`, it overflows and becomes `4294967295`.

## Fix
Use `std::string::size_type` instead of `__u32`.
`std::string::size_type` is the correct return type for `std::basic_string::find`.

Alternatively, we can use the `auto` keyword without `std::string::size_type` explicitly.
