### PR TITLE
Support devices with multiple interfaces

### DIFF
--- a/device-libusb.cpp
+++ b/device-libusb.cpp
@@ -129,6 +129,28 @@ int connect_device(int vendor_id, int product_id) {
 		return result;
 	}
 
+	int config = 0;
+	result = libusb_get_configuration(dev_handle, &config);
+	if (result != LIBUSB_SUCCESS) {
+		fprintf(stderr, "libusb_get_configuration() failed: %s\n",
+				libusb_strerror((libusb_error)result));
+		return result;
+	}
+
+	for (int i = 0; i < device_device_desc.bNumConfigurations; i++) {
+		if (device_config_desc[i]->bConfigurationValue != config)
+			continue;
+		for (int j = 0; j < device_config_desc[i]->bNumInterfaces; j++)
+			libusb_detach_kernel_driver(dev_handle, j);
+	}
+
+	result = libusb_reset_device(dev_handle);
+	if (result != LIBUSB_SUCCESS) {
+		fprintf(stderr, "libusb_reset_device() failed: %s\n",
+				libusb_strerror((libusb_error)result));
+		return result;
+	}
+
 	//check that device is responsive
 	unsigned char unused[4];
 	result = libusb_get_string_descriptor(dev_handle, 0, 0, unused, sizeof(unused));

--- a/device-libusb.cpp
+++ b/device-libusb.cpp
@@ -186,19 +186,27 @@ void set_configuration(int configuration) {
 	}
 }
 
-void claim_interface(uint8_t interface) {
+void claim_interface(int interface) {
 	int result = libusb_claim_interface(dev_handle, interface);
 	if (result != LIBUSB_SUCCESS) {
 		fprintf(stderr, "Error claiming interface(%d): %s\n",
-				(unsigned)interface, libusb_strerror((libusb_error)result));
+				interface, libusb_strerror((libusb_error)result));
 	}
 }
 
-void release_interface(uint8_t interface) {
+void release_interface(int interface) {
 	int result = libusb_release_interface(dev_handle, interface);
 	if (result != LIBUSB_SUCCESS && result != LIBUSB_ERROR_NOT_FOUND) {
 		fprintf(stderr, "Error releasing interface(%d): %s\n",
-				(unsigned)interface, libusb_strerror((libusb_error)result));
+				interface, libusb_strerror((libusb_error)result));
+	}
+}
+
+void set_interface_alt_setting(int interface, int altsetting) {
+	int result = libusb_set_interface_alt_setting(dev_handle, interface, altsetting);
+	if (result != LIBUSB_SUCCESS) {
+		fprintf(stderr, "Error setting interface altsetting(%d, %d): %s\n",
+				interface, altsetting, libusb_strerror((libusb_error)result));
 	}
 }
 

--- a/device-libusb.cpp
+++ b/device-libusb.cpp
@@ -274,7 +274,7 @@ void receive_data(uint8_t endpoint, uint8_t attributes, uint16_t maxPacketSize,
 			fprintf(stderr, "Isochronous(read) endpoint EP%02x unhandled.\n", endpoint);
 		break;
 	case USB_ENDPOINT_XFER_BULK:
-		*dataptr = (uint8_t *) malloc(maxPacketSize * 8);
+		*dataptr = new uint8_t[maxPacketSize * 8];
 		do {
 			result = libusb_bulk_transfer(dev_handle, endpoint, *dataptr, maxPacketSize, length, timeout);
 			if (result == LIBUSB_SUCCESS && verbose_level > 2)
@@ -286,7 +286,7 @@ void receive_data(uint8_t endpoint, uint8_t attributes, uint16_t maxPacketSize,
 		} while ((result == LIBUSB_ERROR_PIPE || result == LIBUSB_ERROR_TIMEOUT) && attempt < MAX_ATTEMPTS);
 		break;
 	case USB_ENDPOINT_XFER_INT:
-		*dataptr = (uint8_t *) malloc(maxPacketSize);
+		*dataptr = new uint8_t[maxPacketSize];
 		result = libusb_interrupt_transfer(dev_handle, endpoint, *dataptr, maxPacketSize, length, timeout);
 		if (result == LIBUSB_SUCCESS && verbose_level > 2)
 			printf("Received int data(%d) bytes\n", *length);

--- a/device-libusb.h
+++ b/device-libusb.h
@@ -16,8 +16,9 @@ extern pthread_t hotplug_monitor_thread;
 
 int connect_device(int vendorId, int productId);
 void set_configuration(int configuration);
-void claim_interface(uint8_t interface);
-void release_interface(uint8_t interface);
+void claim_interface(int interface);
+void release_interface(int interface);
+void set_interface_alt_setting(int interface, int altsetting);
 int control_request(const usb_ctrlrequest *setup_packet, int *nbytes,
 			unsigned char **dataptr, int timeout);
 void send_data(uint8_t endpoint, uint8_t attributes, uint8_t *dataptr,

--- a/host-raw-gadget.cpp
+++ b/host-raw-gadget.cpp
@@ -16,10 +16,7 @@
 
 #include "host-raw-gadget.h"
 
-struct usb_device_descriptor		host_device_desc;
-struct raw_gadget_config_descriptor	*host_config_desc;
-
-struct endpoint_thread *ep_thread_list;
+struct raw_gadget_device host_device_desc;
 
 /*----------------------------------------------------------------------*/
 

--- a/host-raw-gadget.h
+++ b/host-raw-gadget.h
@@ -82,26 +82,6 @@ struct usb_raw_eps_info {
 
 /*----------------------------------------------------------------------*/
 
-struct raw_gadget_interface_descriptor {
-	struct usb_interface_descriptor		interface;
-	struct usb_endpoint_descriptor		*endpoints;
-};
-
-struct raw_gadget_interface {
-	struct raw_gadget_interface_descriptor	*altsetting;
-	int					num_altsetting;
-};
-
-struct raw_gadget_config_descriptor {
-	struct usb_config_descriptor		config;
-	struct raw_gadget_interface		*interfaces;
-};
-
-extern struct usb_device_descriptor 		host_device_desc;
-extern struct raw_gadget_config_descriptor	*host_config_desc;
-
-/*----------------------------------------------------------------------*/
-
 #define EP_MAX_PACKET_CONTROL	1024
 #define EP_MAX_PACKET_BULK	1024
 #define EP_MAX_PACKET_INT	8
@@ -135,7 +115,7 @@ struct usb_raw_transfer_io {
 
 struct thread_info {
 	int				fd;
-	int				ep_num = -1;
+	int				ep_num;
 	struct usb_endpoint_descriptor 	endpoint;
 	std::string			transfer_type;
 	std::string			dir;
@@ -143,13 +123,36 @@ struct thread_info {
 	std::mutex			*data_mutex;
 };
 
-struct endpoint_thread {
-	pthread_t			ep_thread_read;
-	pthread_t			ep_thread_write;
-	struct thread_info		ep_thread_info;
+struct raw_gadget_endpoint {
+	struct usb_endpoint_descriptor	endpoint;
+	pthread_t			thread_read;
+	pthread_t			thread_write;
+	struct thread_info		thread_info;
 };
 
-extern endpoint_thread *ep_thread_list;
+struct raw_gadget_altsetting {
+	struct usb_interface_descriptor	interface;
+	struct raw_gadget_endpoint	*endpoints;
+};
+
+struct raw_gadget_interface {
+	struct raw_gadget_altsetting	*altsettings;
+	int				num_altsettings;
+	int				current_altsetting;
+};
+
+struct raw_gadget_config {
+	struct usb_config_descriptor	config;
+	struct raw_gadget_interface	*interfaces;
+};
+
+struct raw_gadget_device {
+	struct usb_device_descriptor 	device;
+	struct raw_gadget_config	*configs;
+	int				current_config;
+};
+
+extern struct raw_gadget_device host_device_desc;
 
 /*----------------------------------------------------------------------*/
 

--- a/misc.h
+++ b/misc.h
@@ -17,10 +17,6 @@ extern int verbose_level;
 extern bool please_stop_ep0;
 extern bool please_stop_eps;
 
-extern int desired_configuration;
-extern int desired_interface;
-extern int desired_interface_altsetting;
-
 extern bool injection_enabled;
 extern std::string injection_file;
 extern Json::Value injection_config;

--- a/proxy.cpp
+++ b/proxy.cpp
@@ -94,7 +94,7 @@ void printData(struct usb_raw_transfer_io io, __u8 bEndpointAddress, std::string
 	printf("Sending data to EP%x(%s_%s):", bEndpointAddress,
 		transfer_type.c_str(), dir.c_str());
 	for (unsigned int i = 0; i < io.inner.length; i++) {
-		printf(" %02x", (unsigned)io.data[i]);
+		printf(" %02hhx", (unsigned)io.data[i]);
 	}
 	printf("\n");
 }

--- a/proxy.cpp
+++ b/proxy.cpp
@@ -405,8 +405,6 @@ void ep0_loop(int fd) {
 					release_interface(desired_interface);
 
 					terminate_eps(fd, previous_interface, previous_interface_altsetting);
-
-					set_configuration(event.ctrl.wValue);
 				}
 
 				for (int i = 0; i < host_device_desc.bNumConfigurations; i++) {
@@ -414,6 +412,9 @@ void ep0_loop(int fd) {
 						desired_configuration = i;
 					}
 				}
+
+				usb_raw_configure(fd);
+				set_configuration(event.ctrl.wValue);
 				claim_interface(desired_interface);
 				process_eps(fd);
 

--- a/proxy.cpp
+++ b/proxy.cpp
@@ -100,14 +100,14 @@ void printData(struct usb_raw_transfer_io io, __u8 bEndpointAddress, std::string
 }
 
 void *ep_loop_write(void *arg) {
-	struct thread_info ep_thread_info = *((struct thread_info*) arg);
-	int fd = ep_thread_info.fd;
-	int ep_num = ep_thread_info.ep_num;
-	struct usb_endpoint_descriptor ep = ep_thread_info.endpoint;
-	std::string transfer_type = ep_thread_info.transfer_type;
-	std::string dir = ep_thread_info.dir;
-	std::deque<usb_raw_transfer_io> *data_queue = ep_thread_info.data_queue;
-	std::mutex *data_mutex = ep_thread_info.data_mutex;
+	struct thread_info thread_info = *((struct thread_info*) arg);
+	int fd = thread_info.fd;
+	int ep_num = thread_info.ep_num;
+	struct usb_endpoint_descriptor ep = thread_info.endpoint;
+	std::string transfer_type = thread_info.transfer_type;
+	std::string dir = thread_info.dir;
+	std::deque<usb_raw_transfer_io> *data_queue = thread_info.data_queue;
+	std::mutex *data_mutex = thread_info.data_mutex;
 
 	printf("Start writing thread for EP%02x, thread id(%d)\n",
 		ep.bEndpointAddress, gettid());
@@ -151,14 +151,14 @@ void *ep_loop_write(void *arg) {
 }
 
 void *ep_loop_read(void *arg) {
-	struct thread_info ep_thread_info = *((struct thread_info*) arg);
-	int fd = ep_thread_info.fd;
-	int ep_num = ep_thread_info.ep_num;
-	struct usb_endpoint_descriptor ep = ep_thread_info.endpoint;
-	std::string transfer_type = ep_thread_info.transfer_type;
-	std::string dir = ep_thread_info.dir;
-	std::deque<usb_raw_transfer_io> *data_queue = ep_thread_info.data_queue;
-	std::mutex *data_mutex = ep_thread_info.data_mutex;
+	struct thread_info thread_info = *((struct thread_info*) arg);
+	int fd = thread_info.fd;
+	int ep_num = thread_info.ep_num;
+	struct usb_endpoint_descriptor ep = thread_info.endpoint;
+	std::string transfer_type = thread_info.transfer_type;
+	std::string dir = thread_info.dir;
+	std::deque<usb_raw_transfer_io> *data_queue = thread_info.data_queue;
+	std::mutex *data_mutex = thread_info.data_mutex;
 
 	printf("Start reading thread for EP%02x, thread id(%d)\n",
 		ep.bEndpointAddress, gettid());
@@ -227,95 +227,91 @@ void *ep_loop_read(void *arg) {
 	return NULL;
 }
 
-void process_eps(int fd) {
-	struct raw_gadget_interface_descriptor temp_interface = host_config_desc[desired_configuration]
-								.interfaces[desired_interface]
-								.altsetting[desired_interface_altsetting];
-	ep_thread_list = new struct endpoint_thread[temp_interface.interface.bNumEndpoints];
-	printf("bNumEndpoints is %d\n", static_cast<int>(temp_interface.interface.bNumEndpoints));
+void process_eps(int fd, int config, int interface, int altsetting) {
+	struct raw_gadget_altsetting *alt = &host_device_desc.configs[config]
+					.interfaces[interface].altsettings[altsetting];
 
-	for (int i = 0; i < temp_interface.interface.bNumEndpoints; i++) {
-		int addr = usb_endpoint_num(&temp_interface.endpoints[i]);
+	printf("Activating %d endpoints on interface %d\n", (int)alt->interface.bNumEndpoints, interface);
+
+	for (int i = 0; i < alt->interface.bNumEndpoints; i++) {
+		struct raw_gadget_endpoint *ep = &alt->endpoints[i];
+
+		int addr = usb_endpoint_num(&ep->endpoint);
 		assert(addr != 0);
 
-		ep_thread_list[i].ep_thread_info.fd = fd;
-		ep_thread_list[i].ep_thread_info.endpoint = temp_interface.endpoints[i];
-		ep_thread_list[i].ep_thread_info.data_queue = new std::deque<usb_raw_transfer_io>;
-		ep_thread_list[i].ep_thread_info.data_mutex = new std::mutex;
+		ep->thread_info.fd = fd;
+		ep->thread_info.endpoint = ep->endpoint;
+		ep->thread_info.data_queue = new std::deque<usb_raw_transfer_io>;
+		ep->thread_info.data_mutex = new std::mutex;
 
-		switch (usb_endpoint_type(&temp_interface.endpoints[i])) {
+		switch (usb_endpoint_type(&ep->endpoint)) {
 		case USB_ENDPOINT_XFER_ISOC:
-			ep_thread_list[i].ep_thread_info.transfer_type = "isoc";
+			ep->thread_info.transfer_type = "isoc";
 			break;
 		case USB_ENDPOINT_XFER_BULK:
-			ep_thread_list[i].ep_thread_info.transfer_type = "bulk";
+			ep->thread_info.transfer_type = "bulk";
 			break;
 		case USB_ENDPOINT_XFER_INT:
-			ep_thread_list[i].ep_thread_info.transfer_type = "int";
+			ep->thread_info.transfer_type = "int";
 			break;
 		default:
-			printf("transfer_type %d is invalid\n", usb_endpoint_type(&temp_interface.endpoints[i]));
+			printf("transfer_type %d is invalid\n", usb_endpoint_type(&ep->endpoint));
 			assert(false);
 		}
 
-		if (usb_endpoint_dir_in(&temp_interface.endpoints[i]))
-			ep_thread_list[i].ep_thread_info.dir = "in";
+		if (usb_endpoint_dir_in(&ep->endpoint))
+			ep->thread_info.dir = "in";
 		else
-			ep_thread_list[i].ep_thread_info.dir = "out";
+			ep->thread_info.dir = "out";
 
-		ep_thread_list[i].ep_thread_info.ep_num = usb_raw_ep_enable(fd,
-					&ep_thread_list[i].ep_thread_info.endpoint);
+		ep->thread_info.ep_num = usb_raw_ep_enable(fd, &ep->thread_info.endpoint);
 		printf("%s_%s: addr = %u, ep = #%d\n",
-			ep_thread_list[i].ep_thread_info.transfer_type.c_str(),
-			ep_thread_list[i].ep_thread_info.dir.c_str(),
-			addr, ep_thread_list[i].ep_thread_info.ep_num);
+			ep->thread_info.transfer_type.c_str(),
+			ep->thread_info.dir.c_str(),
+			addr, ep->thread_info.ep_num);
 
 		if (verbose_level)
 			printf("Creating thread for EP%02x\n",
-				ep_thread_list[i].ep_thread_info.endpoint.bEndpointAddress);
-		pthread_create(&ep_thread_list[i].ep_thread_read, 0,
-			ep_loop_read, (void *) &ep_thread_list[i].ep_thread_info);
-		pthread_create(&ep_thread_list[i].ep_thread_write, 0,
-			ep_loop_write, (void *) &ep_thread_list[i].ep_thread_info);
+				ep->thread_info.endpoint.bEndpointAddress);
+		pthread_create(&ep->thread_read, 0,
+			ep_loop_read, (void *)&ep->thread_info);
+		pthread_create(&ep->thread_write, 0,
+			ep_loop_write, (void *)&ep->thread_info);
 	}
 
 	printf("process_eps done\n");
 }
 
-void terminate_eps(int fd, int interface, int altsetting) {
-	int thread_num = host_config_desc[desired_configuration]
-			.interfaces[interface]
-			.altsetting[altsetting]
-			.interface
-			.bNumEndpoints;
+void terminate_eps(int fd, int config, int interface, int altsetting) {
+	struct raw_gadget_altsetting *alt = &host_device_desc.configs[config]
+					.interfaces[interface].altsettings[altsetting];
 
 	please_stop_eps = true;
 
-	for (int i = 0; i < thread_num; i++) {
-		if (ep_thread_list[i].ep_thread_read &&
-			pthread_join(ep_thread_list[i].ep_thread_read, NULL)) {
-			fprintf(stderr, "Error join ep_thread_read\n");
-		}
-		if (ep_thread_list[i].ep_thread_write &&
-			pthread_join(ep_thread_list[i].ep_thread_write, NULL)) {
-			fprintf(stderr, "Error join ep_thread_write\n");
-		}
+	for (int i = 0; i < alt->interface.bNumEndpoints; i++) {
+		struct raw_gadget_endpoint *ep = &alt->endpoints[i];
 
-		usb_raw_ep_disable(fd, ep_thread_list[i].ep_thread_info.ep_num);
+		if (ep->thread_read && pthread_join(ep->thread_read, NULL)) {
+			fprintf(stderr, "Error join thread_read\n");
+		}
+		if (ep->thread_write && pthread_join(ep->thread_write, NULL)) {
+			fprintf(stderr, "Error join thread_write\n");
+		}
+		ep->thread_read = 0;
+		ep->thread_write = 0;
 
-		delete ep_thread_list[i].ep_thread_info.data_queue;
-		delete ep_thread_list[i].ep_thread_info.data_mutex;
+		usb_raw_ep_disable(fd, ep->thread_info.ep_num);
+		ep->thread_info.ep_num = -1;
+
+		delete ep->thread_info.data_queue;
+		delete ep->thread_info.data_mutex;
 	}
-	delete[] ep_thread_list;
 
 	please_stop_eps = false;
 }
 
 void ep0_loop(int fd) {
 	bool set_configuration_done_once = false;
-	int previous_bConfigurationValue = -1;
-	int previous_interface = 0;
-	int previous_interface_altsetting = 0;
 
 	printf("Start for EP0, thread id(%d)\n", gettid());
 
@@ -387,82 +383,88 @@ void ep0_loop(int fd) {
 			rv = usb_raw_ep0_read(fd, (struct usb_raw_ep_io *)&io);
 
 			if (event.ctrl.bRequestType == 0x00 && event.ctrl.bRequest == 0x09) { // Set configuration
-				if (previous_bConfigurationValue == event.ctrl.wValue) {
-					printf("Skip changing configuration, wValue is same as previous\n");
-					continue;
+				int desired_config = -1;
+				for (int i = 0; i < host_device_desc.device.bNumConfigurations; i++) {
+					if (host_device_desc.configs[i].config.bConfigurationValue == event.ctrl.wValue) {
+						desired_config = i;
+						break;
+					}
 				}
-
-				if (event.ctrl.wValue > host_device_desc.bNumConfigurations) {
+				if (desired_config < 0) {
 					printf("[Warning] Skip changing configuration, wValue(%d) is invalid\n", event.ctrl.wValue);
 					continue;
 				}
 
+				struct raw_gadget_config *config = &host_device_desc.configs[desired_config];
+
 				if (set_configuration_done_once) { // Need to stop all threads for eps and cleanup
 					printf("Changing configuration\n");
-
-					desired_interface = 0;
-					desired_interface_altsetting = 0;
-					release_interface(desired_interface);
-
-					terminate_eps(fd, previous_interface, previous_interface_altsetting);
-				}
-
-				for (int i = 0; i < host_device_desc.bNumConfigurations; i++) {
-					if (host_config_desc[i].config.bConfigurationValue == event.ctrl.wValue) {
-						desired_configuration = i;
+					for (int i = 0; i < config->config.bNumInterfaces; i++) {
+						struct raw_gadget_interface *iface = &config->interfaces[i];
+						int interface_num = iface->altsettings[iface->current_altsetting]
+							.interface.bInterfaceNumber;
+						terminate_eps(fd, host_device_desc.current_config, i,
+								iface->current_altsetting);
+						release_interface(interface_num);
 					}
 				}
 
 				usb_raw_configure(fd);
-				set_configuration(event.ctrl.wValue);
-				claim_interface(desired_interface);
-				process_eps(fd);
+				set_configuration(config->config.bConfigurationValue);
+				host_device_desc.current_config = desired_config;
+
+				for (int i = 0; i < config->config.bNumInterfaces; i++) {
+					struct raw_gadget_interface *iface = &config->interfaces[i];
+					iface->current_altsetting = 0;
+					int interface_num = iface->altsettings[0].interface.bInterfaceNumber;
+					claim_interface(interface_num);
+					process_eps(fd, desired_config, i, 0);
+				}
 
 				set_configuration_done_once = true;
-				previous_bConfigurationValue = event.ctrl.wValue;
-				previous_interface = desired_interface;
-				previous_interface_altsetting = desired_interface_altsetting;
 			}
 			else if (event.ctrl.bRequestType == 0x01 && event.ctrl.bRequest == 0x0b) { // Set interface/alt_setting
-				bool process_eps_required = false;
+				struct raw_gadget_config *config =
+					&host_device_desc.configs[host_device_desc.current_config];
 
-				if (event.ctrl.wIndex >= host_config_desc[desired_configuration].config.bNumInterfaces) {
+				int desired_interface = -1;
+				for (int i = 0; i < config->config.bNumInterfaces; i++) {
+					if (config->interfaces[i].altsettings[0].interface.bInterfaceNumber ==
+							event.ctrl.wIndex) {
+						desired_interface = i;
+						break;
+					}
+				}
+				if (desired_interface < 0) {
 					printf("[Warning] Skip changing interface, wIndex(%d) is invalid\n", event.ctrl.wIndex);
 					continue;
 				}
-				if (event.ctrl.wValue >= host_config_desc[desired_configuration]
-							.interfaces[event.ctrl.wIndex].num_altsetting) {
+
+				struct raw_gadget_interface *iface = &config->interfaces[desired_interface];
+
+				int desired_altsetting = -1;
+				for (int i = 0; i < iface->num_altsettings; i++) {
+					if (iface->altsettings[i].interface.bAlternateSetting == event.ctrl.wValue) {
+						desired_altsetting = i;
+						break;
+					}
+				}
+				if (desired_altsetting < 0) {
 					printf("[Warning] Skip changing alt_setting, wValue(%d) is invalid\n", event.ctrl.wValue);
 					continue;
 				}
 
-				desired_interface = event.ctrl.wIndex;
-				desired_interface_altsetting = event.ctrl.wValue;
+				struct raw_gadget_altsetting *alt = &iface->altsettings[desired_altsetting];
 
-				if (previous_interface != desired_interface) {
-					printf("Will change interface from %d to %d\n",
-						previous_interface, desired_interface);
-					release_interface(previous_interface);
-					process_eps_required = true;
-				}
-				if (previous_interface_altsetting != desired_interface_altsetting) {
-					printf("Will Change alt_setting from %d to %d\n",
-						previous_interface_altsetting, desired_interface_altsetting);
-					process_eps_required = true;
-				}
+				printf("Changing interface/altsetting\n");
 
-				if (process_eps_required) { // Need to stop all threads for eps and cleanup
-					printf("Changing interface/altsetting\n");
-
-					terminate_eps(fd, previous_interface, previous_interface_altsetting);
-
-					if (previous_interface != desired_interface)
-						claim_interface(desired_interface);
-					process_eps(fd);
-				}
-
-				previous_interface = desired_interface;
-				previous_interface_altsetting = desired_interface_altsetting;
+				terminate_eps(fd, host_device_desc.current_config,
+					desired_interface, iface->current_altsetting);
+				set_interface_alt_setting(alt->interface.bInterfaceNumber,
+					alt->interface.bAlternateSetting);
+				process_eps(fd, host_device_desc.current_config,
+					desired_interface, desired_altsetting);
+				iface->current_altsetting = desired_altsetting;
 			}
 			else {
 				if (injection_enabled) {
@@ -499,6 +501,17 @@ void ep0_loop(int fd) {
 		}
 
 		delete[] control_data;
+	}
+
+	struct raw_gadget_config *config = &host_device_desc.configs[host_device_desc.current_config];
+
+	for (int i = 0; i < config->config.bNumInterfaces; i++) {
+		struct raw_gadget_interface *iface = &config->interfaces[i];
+		int interface_num = iface->altsettings[iface->current_altsetting]
+			.interface.bInterfaceNumber;
+		terminate_eps(fd, host_device_desc.current_config, i,
+				iface->current_altsetting);
+		release_interface(interface_num);
 	}
 
 	printf("End for EP0, thread id(%d)\n", gettid());


### PR DESCRIPTION
A few fixes that should hopefully resolve #4, see the last patch. Devices with multiple interfaces should now work properly.

With these changes, I'm able to proxy the [K12 keyboard](https://www.amazon.es/Rii-K12-Mini-touchpad-inoxidable/dp/B00ZCFTT00/) without issues.

I think devices that switch between configurations/alt settings will still glitch: endpoint handling threads are not joined properly as they are blocked on `receive_data()`. But this issue is present in the current code and will require another fix.