### PR TITLE
Patch bMaxPacketSize0 to be at least 64 

### DIFF
--- a/proxy.cpp
+++ b/proxy.cpp
@@ -369,6 +369,18 @@ void ep0_loop(int fd) {
 					}
 				}
 
+				// Some UDCs require bMaxPacketSize0 to be at least 64.
+				// Ideally, the information about UDC limitations needs to be
+				// exposed by Raw Gadget, but this is not implemented at the moment;
+				// see https://github.com/xairy/raw-gadget/issues/41.
+				if ((event.ctrl.bRequestType & USB_TYPE_MASK) == USB_TYPE_STANDARD &&
+				    event.ctrl.bRequest == USB_REQ_GET_DESCRIPTOR &&
+				    (event.ctrl.wValue >> 8) == USB_DT_DEVICE) {
+					struct usb_device_descriptor *dev = (struct usb_device_descriptor *)&io.data;
+					if (dev->bMaxPacketSize0 < 64)
+						dev->bMaxPacketSize0 = 64;
+				}
+
 				if (verbose_level >= 2)
 					printData(io, 0x00, "control", "in");
 

--- a/proxy.cpp
+++ b/proxy.cpp
@@ -394,7 +394,8 @@ void ep0_loop(int fd) {
 		else {
 			rv = usb_raw_ep0_read(fd, (struct usb_raw_ep_io *)&io);
 
-			if (event.ctrl.bRequestType == 0x00 && event.ctrl.bRequest == 0x09) { // Set configuration
+			if ((event.ctrl.bRequestType & USB_TYPE_MASK) == USB_TYPE_STANDARD &&
+					event.ctrl.bRequest == USB_REQ_SET_CONFIGURATION) {
 				int desired_config = -1;
 				for (int i = 0; i < host_device_desc.device.bNumConfigurations; i++) {
 					if (host_device_desc.configs[i].config.bConfigurationValue == event.ctrl.wValue) {
@@ -435,7 +436,8 @@ void ep0_loop(int fd) {
 
 				set_configuration_done_once = true;
 			}
-			else if (event.ctrl.bRequestType == 0x01 && event.ctrl.bRequest == 0x0b) { // Set interface/alt_setting
+			else if ((event.ctrl.bRequestType & USB_TYPE_MASK) == USB_TYPE_STANDARD &&
+					event.ctrl.bRequest == USB_REQ_SET_INTERFACE) {
 				struct raw_gadget_config *config =
 					&host_device_desc.configs[host_device_desc.current_config];
 


### PR DESCRIPTION
A lot of UDCs require `bMaxPacketSize0`  to be at least `64` for High Speed devices (usb-proxy always uses High Speed right now) due to their hardware limitations:  [dwc2](https://elixir.bootlin.com/linux/latest/source/drivers/usb/dwc2/core.h#L68), [dwc3](https://elixir.bootlin.com/linux/v6.6-rc7/source/drivers/usb/dwc3/gadget.c#L4124), [musb](https://elixir.bootlin.com/linux/latest/source/drivers/usb/musb/musb_gadget.c#L1714) (also [dummy](https://elixir.bootlin.com/linux/v6.6-rc7/source/drivers/usb/gadget/udc/dummy_hcd.c#L892)).

Thus, patch this value into the device descriptor dynamically.

As mentioned in the comment, Raw Gadget should expose this information, but this is [not implemented](https://github.com/xairy/raw-gadget/issues/41) at the moment.

Providing a lower `bMaxPacketSize0` works fine sometimes, but e.g. providing `bMaxPacketSize0` of `8` fails with `dwc3` with a Windows host (Linux, interestingly, works fine).

This issue also came up during the discussion in one of the [previous PRs](https://github.com/AristoChen/usb-proxy/issues/4#issuecomment-1543252957).