### PR TITLE
Support proxying devices with isochronous IN endpoints

### DIFF
--- a/device-libusb.cpp
+++ b/device-libusb.cpp
@@ -245,7 +245,7 @@ int control_request(const usb_ctrlrequest *setup_packet, int *nbytes,
 }
 
 int send_data(uint8_t endpoint, uint8_t attributes, uint8_t *dataptr,
-			int length) {
+			int length, int timeout) {
 	int transferred;
 	int attempt = 0;
 	int result = LIBUSB_SUCCESS;
@@ -262,7 +262,7 @@ int send_data(uint8_t endpoint, uint8_t attributes, uint8_t *dataptr,
 		break;
 	case USB_ENDPOINT_XFER_BULK:
 		do {
-			result = libusb_bulk_transfer(dev_handle, endpoint, dataptr, length, &transferred, 0);
+			result = libusb_bulk_transfer(dev_handle, endpoint, dataptr, length, &transferred, timeout);
 			//TODO retry transfer if incomplete
 			if (transferred != length) {
 				fprintf(stderr, "Incomplete Bulk transfer on EP%02x for attempt %d. length(%d), transferred(%d)\n",
@@ -284,7 +284,7 @@ int send_data(uint8_t endpoint, uint8_t attributes, uint8_t *dataptr,
 					&& attempt < MAX_ATTEMPTS);
 		break;
 	case USB_ENDPOINT_XFER_INT:
-		result = libusb_interrupt_transfer(dev_handle, endpoint, dataptr, length, &transferred, 0);
+		result = libusb_interrupt_transfer(dev_handle, endpoint, dataptr, length, &transferred, timeout);
 
 		if (transferred != length)
 			fprintf(stderr, "Incomplete Interrupt transfer on EP%02x\n", endpoint);
@@ -302,7 +302,6 @@ int send_data(uint8_t endpoint, uint8_t attributes, uint8_t *dataptr,
 int receive_data(uint8_t endpoint, uint8_t attributes, uint16_t maxPacketSize,
 			uint8_t **dataptr, int *length, int timeout) {
 	int result = LIBUSB_SUCCESS;
-	timeout = 0;
 
 	int attempt = 0;
 	switch (attributes & USB_ENDPOINT_XFERTYPE_MASK) {

--- a/device-libusb.cpp
+++ b/device-libusb.cpp
@@ -14,8 +14,7 @@ int hotplug_callback(struct libusb_context *ctx __attribute__((unused)),
 			struct libusb_device *dev __attribute__((unused)),
 			libusb_hotplug_event envet __attribute__((unused)),
 			void *user_data __attribute__((unused))) {
-	printf("Hotplug event\n");
-
+	printf("Hotplug event: device disconnected, stopping proxy...\n");
 	kill(0, SIGINT);
 	return 0;
 }

--- a/device-libusb.h
+++ b/device-libusb.h
@@ -2,6 +2,8 @@
 
 #include "misc.h"
 
+#define USB_REQUEST_TIMEOUT 1000
+
 #define MAX_ATTEMPTS 5
 
 extern libusb_device			**devs;
@@ -23,6 +25,6 @@ void set_interface_alt_setting(int interface, int altsetting);
 int control_request(const usb_ctrlrequest *setup_packet, int *nbytes,
 			unsigned char **dataptr, int timeout);
 int send_data(uint8_t endpoint, uint8_t attributes, uint8_t *dataptr,
-			int length);
+			int length, int timeout);
 int receive_data(uint8_t endpoint, uint8_t attributes, uint16_t maxPacketSize,
 			uint8_t **dataptr, int *length, int timeout);

--- a/host-raw-gadget.cpp
+++ b/host-raw-gadget.cpp
@@ -111,6 +111,11 @@ int usb_raw_ep_read(int fd, struct usb_raw_ep_io *io) {
 			// Ignore failures caused by device reset.
 			return rv;
 		}
+		else if (errno == EINTR) {
+			// Ignore failures caused by sending a signal to the
+			// endpoint threads when shutting them down.
+			return rv;
+		}
 		else if (errno == EBUSY)
 			return rv;
 		perror("ioctl(USB_RAW_IOCTL_EP_READ)");
@@ -128,6 +133,11 @@ int usb_raw_ep_write(int fd, struct usb_raw_ep_io *io) {
 		}
 		else if (errno == ESHUTDOWN) {
 			// Ignore failures caused by device reset.
+			return rv;
+		}
+		else if (errno == EINTR) {
+			// Ignore failures caused by sending a signal to the
+			// endpoint threads when shutting them down.
 			return rv;
 		}
 		else if (errno == EBUSY)

--- a/host-raw-gadget.cpp
+++ b/host-raw-gadget.cpp
@@ -140,6 +140,11 @@ int usb_raw_ep_write(int fd, struct usb_raw_ep_io *io) {
 			// endpoint threads when shutting them down.
 			return rv;
 		}
+		else if (errno == EXDEV || errno == ENODATA) {
+			// Ignore failures caused by sending an isochronous transfer
+			// too late (dwc3 returns EXDEV, dwc2 returns ENODATA).
+			return rv;
+		}
 		else if (errno == EBUSY)
 			return rv;
 		perror("ioctl(USB_RAW_IOCTL_EP_WRITE)");

--- a/host-raw-gadget.h
+++ b/host-raw-gadget.h
@@ -86,33 +86,16 @@ struct usb_raw_eps_info {
 
 /*----------------------------------------------------------------------*/
 
-#define EP_MAX_PACKET_CONTROL	1024
-#define EP_MAX_PACKET_BULK	1024
-#define EP_MAX_PACKET_INT	8
+#define MAX_TRANSFER_SIZE 4096
 
 struct usb_raw_control_event {
 	struct usb_raw_event		inner;
 	struct usb_ctrlrequest		ctrl;
 };
 
-struct usb_raw_control_io {
-	struct usb_raw_ep_io		inner;
-	char				data[EP_MAX_PACKET_CONTROL];
-};
-
-struct usb_raw_bulk_io {
-	struct usb_raw_ep_io		inner;
-	char				data[EP_MAX_PACKET_BULK];
-};
-
-struct usb_raw_int_io {
-	struct usb_raw_ep_io		inner;
-	char				data[EP_MAX_PACKET_INT];
-};
-
 struct usb_raw_transfer_io {
 	struct usb_raw_ep_io		inner;
-	char				data[1024];
+	char				data[MAX_TRANSFER_SIZE];
 };
 
 /*----------------------------------------------------------------------*/

--- a/proxy.cpp
+++ b/proxy.cpp
@@ -145,6 +145,11 @@ void *ep_loop_write(void *arg) {
 					ep.bEndpointAddress, transfer_type.c_str(), dir.c_str());
 				break;
 			}
+			if (rv < 0 && (errno == EXDEV || errno == ENODATA)) {
+				printf("EP%x(%s_%s): missed isochronous timing, ignoring transfer\n",
+					ep.bEndpointAddress, transfer_type.c_str(), dir.c_str());
+				continue;
+			}
 			else if (rv < 0) {
 				perror("usb_raw_ep_write()");
 				exit(EXIT_FAILURE);


### PR DESCRIPTION
With these changes, I'm able to proxy a few Logitech USB web cameras at a low resolution (160x120 pixels) via dwc3.

Proxying with a higher resolution fails to produce a picture on the host: I think because the transfer rate is too low and all the frames get dropped.

I have not tried other UDCs besides dwc3 yet.

Also fixes #13.